### PR TITLE
Pass command line arguments in right way

### DIFF
--- a/linter.py
+++ b/linter.py
@@ -17,7 +17,7 @@ class Mypy(PythonLinter):
     """Provides an interface to mypy."""
 
     syntax = 'python'
-    cmd = 'mypy @'
+    cmd = 'mypy * @'
     version_args = '--version'
     version_re = r'(?P<version>\d+\.\d+\.\d+)'
     version_requirement = '>= 0.2'


### PR DESCRIPTION
If you want to use mypy linter in python 2 projects, according mypy docs you need to add `--py2` argument. Using *.sublime-project settings I define

``` python
    "SublimeLinter": {
        "@python": 2,
        "linters": {
            "mypy": {
                "args": "--py2"
            }
        }
    }
```

But I receive 
`mypy: can't read file '--py2': No such file or directory`

So, adding asterics to cmd property will insert args in right way
