### PR TITLE
Update for new mypy versioning

### DIFF
--- a/linter.py
+++ b/linter.py
@@ -20,7 +20,7 @@ class Mypy(PythonLinter):
     syntax = 'python'
     cmd = 'mypy * @'
     version_args = '--version'
-    version_re = r'(?P<version>\d+\.\d+\.\d+)'
+    version_re = r'(?P<version>\d+\.\d+)'
     version_requirement = '>= 0.2'
     regex = r'^.+\.py:(?P<line>\d+): error: (?P<message>.+)'
     multiline = False


### PR DESCRIPTION
The new mypy versioning uses, for example, `mypy 0.470`. This fails the version requirement on the current regex. Since this linter only requires a version higher than 0.2, the last digit isn't even needed, so ignoring it will be fine for both the new and old versioning.