### PR TITLE
Use mypy instead mypy-lang

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Before using this plugin, you must ensure that `mypy` is installed on your syste
 
 1. Install `mypy` by typing the following in a terminal:
    ```
-   [sudo] pip install mypy-lang
+   [sudo] pip install mypy
    ```
 
 


### PR DESCRIPTION
As of mypy version 0.470, the package name `mypy-lang` has been replaced with package name `mypy`. See http://mypy-lang.blogspot.com/2017/01/mypy-0470-released.html