### PR TITLE
Rewrite the entire linter to support new options and make it actually work

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Before using this plugin, you must ensure that `mypy` is installed on your syste
    ```
 
 
-**Note:** This plugin requires `mypy` 0.2.0 or later.
+**Note:** This plugin requires `mypy` 0.520 or later.
 
 ### Linter configuration
 In order for `mypy` to be executed by SublimeLinter, you must ensure that its path is available to SublimeLinter. Before going any further, please read and follow the steps in [“Finding a linter executable”](http://sublimelinter.readthedocs.org/en/latest/troubleshooting.html#finding-a-linter-executable) through “Validating your PATH” in the documentation.
@@ -40,6 +40,15 @@ To install via Package Control, do the following:
 ## Settings
 For general information on how SublimeLinter works with settings, please see [Settings][settings]. For information on generic linter settings, please see [Linter Settings][linter-settings].
 
+|Setting|Description|Inline Setting|Inline Override|
+|:------|:----------|:------------:|:-------------:|
+|disallow-any|A comma-separated list of the various types of Any in a module to disallow.|&#10003;|&#10003;|
+|strict-optional-whitelist|A comma-separated list of GLOBs for files to ignore strict optional checking.|&#10003;|&#10003;|
+|python-version|The Python version that mypy should use for its type stubs.|&#10003;| |
+|cache-dir|The directory to store the cache in. Creates a sub-folder in your temporary directory if not specified.| | |
+|config-file|Path to the config file to use. A file named `mypy.ini` is recognized automatically.| | |
+
+All other args to mypy should be specified in the `args` list, since they are just flags, rarely used or don't make sense to be recognized as an inline setting.
 
 ## Contributing
 If you would like to contribute enhancements or fixes, please do the following:

--- a/linter.py
+++ b/linter.py
@@ -4,51 +4,190 @@
 #
 # Written by Fred Callaway
 # Copyright (c) 2015 Fred Callaway
+# Copyright (c) 2017 FichteFoll <fichtefoll2@googlemail.com>
 #
 # License: MIT
 #
 
 """This module exports the Mypy plugin class."""
 
-from SublimeLinter.lint import PythonLinter, util, highlight
-import sublime
+import os
+import shutil
+import tempfile
+
+from SublimeLinter.lint import PythonLinter, util, highlight, persist
+
+TMPDIR_PREFIX = "SublimeLinter-contrib-mypy-"
+
+# Mapping for our created temporary directories.
+# For smarter caching purposes,
+# we index different cache folders based on the working dir.
+tmpdirs = {}  # type: Dict[str, tempfile.TemporaryDirectory]
 
 
 class Mypy(PythonLinter):
     """Provides an interface to mypy."""
 
     syntax = 'python'
-    cmd = 'mypy --follow-imports silent * @'
+    executable = "mypy"
     version_args = '--version'
-    version_re = r'(?P<version>\d+\.\d+)'
-    version_requirement = '>= 0.2'
-    regex = r'^.+\.py:(?P<line>\d+): (?:error|warning|note): (?P<message>.+)'
-    multiline = False
-    template_suffix = '-'
-    line_col_base = (1, 1)
-    tempfile_suffix = None
+    version_re = r'(?P<version>\d+\.\d+(\.\d+)?)'
+    version_requirement = '>= 0.520'
+
+    regex = r'^.+\.py:(?P<line>\d+):(?P<col>\d+): error: (?P<message>.+)'
     error_stream = util.STREAM_BOTH
-    selectors = {}
-    word_re = None
-    defaults = {}
+    line_col_base = (1, 0)
+    # multiline = False
+
+    # mypy takes quite some time, so we only do it on saved files.
+    # If you want it for unsaved files as well,
+    # uncomment the second line below.
+    tempfile_suffix = 'py'
+    tempfile_suffix = '-'
+    config_file = ('--config-file', 'mypy.ini')
+
+    # Pretty much all interesting options don't expect a value,
+    # so you'll have to specify those in "args".
+    # The following are mostly provided
+    # because of their usage for inline settings/overrides.
+    defaults = {
+        "--strict-optional-whitelist: ": [],
+        "--disallow-any:,": [],
+        "--python-version": "",
+        # Will default to tempfile.TemporaryDirectory if empty.
+        "--cache-dir": "",
+        "--config-file": "",
+    }
     default_type = highlight.WARNING
-    inline_settings = None
-    inline_overrides = None
-    comment_re = None
-    check_version = False
+    inline_settings = (
+        "python-version",
+    )
+    inline_overrides = (
+        "disallow-any",
+        "strict-optional-whitelist",
+    )
+    # selectors = {}
+    # word_re = None
+    # comment_re = r'\s*#'
+    check_version = True
 
-    def run(self, cmd, code):
-        """Override ``run`` method to customize the executable ``cmd``."""
+    # Used to store TemporaryDirectory instances.
+    # Each view gets its own linter instance, apparently.
+    _tmp_dir = None
 
+    def cmd(self):
+        """Return a list with the command line to execute."""
+
+        cmd = [
+            self.executable_path,
+            '*',
+            '--follow-imports=silent',  # or 'skip'
+            '--ignore-missing-imports',
+            '--show-column-numbers',
+            '--hide-error-context',
+            '@'
+        ]
+
+        if self.tempfile_suffix == "-":
+            # --shadow-file SOURCE_FILE SHADOW_FILE
+            #
+            # '@' needs to be the shadow file,
+            # while we request the normal filename
+            # to be checked in its normal environment.
+            # Trying to be smart about view.is_dirty and optimizing '--shadow-file' away
+            # doesn't work well with SublimeLinter internals.
+            cmd[-1:] = ['--shadow-file', self.filename, '@', self.filename]
+
+        # Add a temporary cache dir to the command if none was specified.
+        # Helps keep the environment clean
+        # by not littering everything with `.mypy_cache` folders.
         settings = self.get_view_settings()
-        custom_cmd = settings.get('cmd')
-        current_window = sublime.active_window()
+        if not settings.get('cache-dir'):
+            cwd = os.getcwd()
+            if cwd in tmpdirs:
+                cache_dir = tmpdirs[cwd].name
+            else:
+                tmp_dir = tempfile.TemporaryDirectory(prefix=TMPDIR_PREFIX)
+                tmpdirs[cwd] = tmp_dir
+                cache_dir = tmp_dir.name
+                persist.debug("Created temporary cache dir at: " + cache_dir)
+            cmd[1:1] = ["--cache-dir", cache_dir]
 
-        if custom_cmd is not None and current_window is not None:
-            project_vars = current_window.extract_variables()
+        return cmd
 
-            custom_cmd = sublime.expand_variables(
-                custom_cmd, project_vars)
-            cmd = self.insert_args([custom_cmd])
+    def get_chdir(self, settings):
+        """Find the chdir to use with the linter."""
+        # As explained in https://github.com/python/mypy/issues/2974,
+        # we need to overwrite the current working directory
+        # for the executed subprocess
+        # if the file uses relative imports.
+        #
+        # Users could set the `chdir` linter setting,
+        # but they'd have to do it for *every* file using relative imports,
+        # so we just do it for them here if they didn't.
+        chdir = settings.get('chdir', None)
 
-        return super(Mypy, self).run(cmd, code)
+        if chdir and os.path.isdir(chdir):
+            persist.debug('chdir has been set to: {0}'.format(chdir))
+            return chdir
+        else:
+            if self.filename:
+                # Only difference from Linter.get_chdir
+                chdir = _find_first_nonpackage_parent(self.filename)
+                if chdir != os.path.dirname(self.filename):
+                    persist.debug('chdir has been set to: {0}'.format(chdir))
+                return chdir
+                # return os.path.dirname(self.filename)
+            else:
+                return os.path.realpath('.')
+
+    def build_cmd(self, cmd=None):
+        """Fix internal SublimeLinter `build_cmd`.
+
+        PythonLinter doesn't play well with a callable cmd method,
+        so we override this method here.
+        """
+        if not cmd:
+            cmd = self.cmd
+        if callable(cmd):
+            cmd = cmd()
+
+        return self.insert_args(cmd)
+
+
+def _find_first_nonpackage_parent(file_path):
+    dir_path = os.path.dirname(file_path)
+    while os.path.isfile(os.path.join(dir_path, "__init__.py")):
+        parent_path = os.path.dirname(dir_path)
+        if parent_path == dir_path:  # Reached file system root; prevent infinite loop
+            break
+        dir_path = parent_path
+    return dir_path
+
+
+def _onerror(function, path, excinfo):
+    persist.printf("mypy: Unable to delete '{}' while cleaning up temporary directory"
+                   .format(path))
+    import traceback
+    traceback.print_exc(*excinfo)
+
+
+def _cleanup_tmpdirs():
+    tmpdir = tempfile.gettempdir()
+    for dirname in os.listdir(tmpdir):
+        if dirname.startswith(TMPDIR_PREFIX):
+            shutil.rmtree(os.path.join(tmpdir, dirname), onerror=_onerror)
+
+
+def plugin_loaded():
+    """Attempt to clean up temporary directories from previous runs."""
+    _cleanup_tmpdirs()
+
+
+def plugin_unloaded():
+    """Clear references to TemporaryDirectory instances.
+
+    They should then be removed automatically.
+    """
+    # (Actually, do we even need to do this?)
+    tmpdirs.clear()


### PR DESCRIPTION
I was testing out mypy for a side project of mine recently and gave this plugin another visit. Now it actually works properly for everything that's not a stand-alone script and is smarter in various ways.
A list of notable changes follows:

- Requires at least 0.520 (not sure which version exactly, but I tested
  with 0.521).
- Command line is constructed dynamically.
- Supports the `--shadow-file` param, although disabled by default.
  Mypy takes a good 3 seconds to lint anything for me, so having it run
  for every modification barely makes any sense.
- Tries to guess the package's "root" folder in case relative (or
  otherwise absolute) imports are used. Otherwise mypy fails to analyze
  a file with those.
- Imports are silenced but not ignored, so the generate output only
  covers the specified file.
- A temporary directory is created in the user's temp folder to hold
  mypy's caching data. That way it doesn't pollute the various folders
  where a user might store python files in. The directories are cleared
  when the plugin is loaded or unloaded and are only used if the user
  didn't specify a cache-dir setting otherwise.
- `mypy.ini` config files are automatically recognized.