### PR TITLE
constant WARNING will move in SL4 

### DIFF
--- a/linter.py
+++ b/linter.py
@@ -15,7 +15,15 @@ import os
 import shutil
 import tempfile
 
-from SublimeLinter.lint import Linter, util, highlight, persist
+from SublimeLinter.lint import Linter, util, persist
+
+import SublimeLinter
+if getattr(SublimeLinter.lint, 'VERSION', 3) > 3:
+    from SublimeLinter.lint import const
+    WARNING = const.WARNING
+else:
+    from SublimeLinter.lint import highlight
+    WARNING = highlight.WARNING
 
 TMPDIR_PREFIX = "SublimeLinter-contrib-mypy-"
 
@@ -58,7 +66,7 @@ class Mypy(Linter):
         "--cache-dir": "",
         "--config-file": "",
     }
-    default_type = highlight.WARNING
+    default_type = WARNING
     inline_settings = (
         "python-version",
     )


### PR DESCRIPTION
The `WARNING` constant will move from `highlight` to `const`. For the time being it's still available at the old location, but at some point we'll drop that probably. 