### PR TITLE
Make column in Regex expression optional to prevent parsing errors

### DIFF
--- a/linter.py
+++ b/linter.py
@@ -34,7 +34,7 @@ class Mypy(Linter):
     version_re = r'(?P<version>\d+\.\d+(\.\d+)?)'
     version_requirement = '>= 0.520'
 
-    regex = r'^.+\.py:(?P<line>\d+):(?P<col>\d+): error: (?P<message>.+)'
+    regex = r'^.+\.py:(?P<line>\d+):((?P<col>\d+):)? error: (?P<message>.+)'
     error_stream = util.STREAM_BOTH
     line_col_base = (1, 0)
     # multiline = False

--- a/linter.py
+++ b/linter.py
@@ -36,7 +36,7 @@ class Mypy(Linter):
 
     regex = r'^.+\.py:(?P<line>\d+):((?P<col>\d+):)? error: (?P<message>.+)'
     error_stream = util.STREAM_BOTH
-    line_col_base = (1, 0)
+    line_col_base = (1, 1)
     # multiline = False
 
     # mypy takes quite some time, so we only do it on saved files.


### PR DESCRIPTION
This fixes issue #24 by making the column field in Mypy errors optional.