### PR TITLE
fix multiuser environment

### DIFF
--- a/linter.py
+++ b/linter.py
@@ -16,13 +16,14 @@ import os
 import re
 import shutil
 import tempfile
+import getpass
 
 from SublimeLinter.lint import const
 from SublimeLinter.lint import util
 from SublimeLinter.lint import PythonLinter
 
-
-TMPDIR_PREFIX = "SublimeLinter-contrib-mypy-"
+USER = getpass.getuser()
+TMPDIR_PREFIX = "SublimeLinter-contrib-mypy-%s" % USER
 
 logger = logging.getLogger("SublimeLinter.plugin.mypy")
 


### PR DESCRIPTION
Hi, this plugin has the problem that it always throws errors on startup in a multiuser environment (e.g. on a server) when multiple tmp dirs are present with permissions from different users.

I included the username in the tmp-path, which solves this collision, so that only deletion for dirs belonging to the user are attempted.