### PR TITLE
Include notes into linter messages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: python
 
 python:
-  - "3.3"
+  - "3.6"
 
 install:
   - pip install flake8

--- a/linter.py
+++ b/linter.py
@@ -36,7 +36,7 @@ class Mypy(PythonLinter):
     """Provides an interface to mypy."""
 
     executable = "mypy"
-    regex = r'^[^:]+:(?P<line>\d+):((?P<col>\d+):)?\s*((?P<error>error)|(?P<warning>warning)):\s*(?P<message>.+)'
+    regex = r'^[^:]+:(?P<line>\d+):((?P<col>\d+):)?\s*((?P<error>error)|(?P<warning>warning|note)):\s*(?P<message>.+)'
     line_col_base = (1, 1)
     tempfile_suffix = 'py'
     default_type = const.WARNING


### PR DESCRIPTION
Options like --warn-unused-ignores and --warn-redundant-casts output notes, which would otherwise not be displayed