### PR TITLE
Capture `error_type` and drop implicit `code`

### DIFF
--- a/linter.py
+++ b/linter.py
@@ -39,7 +39,7 @@ class Mypy(PythonLinter):
     """Provides an interface to mypy."""
 
     executable = "mypy"
-    regex = r'^[^:]+:(?P<line>\d+):((?P<col>\d+):)?\s*((?P<error>error)|(?P<warning>warning|note)):\s*(?P<message>.+)'
+    regex = r'^[^:]+:(?P<line>\d+):((?P<col>\d+):)?\s*(?P<error_type>[^:]+):\s*(?P<message>.+)'
     line_col_base = (1, 1)
     tempfile_suffix = 'py'
     default_type = const.WARNING


### PR DESCRIPTION
New version of SublimeLinter allows to capture the error_type directly.
A side-effect of this is that `code` stays empty, and therefore the error
panel doesn't show `error  mypy:error` anymore but just `error  mypy`.

(Current behavior is that `error_type` and error `code` are duplicated except
for notes.)