### PR TITLE
Misc improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,9 +42,9 @@ Following is a list of *additional* settings specific to this linter:
 
 |Setting|Description|
 |:------|:----------|
-|cache-dir|The directory to store the cache in. Creates a sub-folder in your temporary directory if not specified.|
-|follow-imports|Whether imports should be followed and linted. The default is `"silent"`, but `"skip"` may also be used. The other options are not interesting.|
-|incremental|By default, we use incremental mode to speed up lint passes. Set this to `false` to disable.|
+|cache-dir|The directory to store the cache in. Creates a sub-folder in your temporary directory if not specified. Set it to `false` to disable this automatic behavior, for example if the cache location is set in your mypy.ini file.|
+|follow-imports|Whether imports should be followed and linted. The default is `"silent"` for speed, but `"normal"` or `"skip"` may also be used.|
+|show-error-codes|Set to `false` for older mypy versions, or better yet update mypy.|
 
 All other args to mypy should be specified in the `args` list directly.
 

--- a/linter.py
+++ b/linter.py
@@ -92,10 +92,9 @@ class Mypy(PythonLinter):
         else:
             cmd.append('${temp_file}')
 
-        # Add a temporary cache dir to the command if none was specified.
-        # Helps keep the environment clean
-        # by not littering everything with `.mypy_cache` folders.
-        if not self.settings.get('cache-dir'):
+        # Compare against `''` so the user can set just `False`,
+        # for example if the cache is configured in "mypy.ini".
+        if self.settings.get('cache-dir') == '':
             cwd = self.get_working_dir()
             if not cwd:  # abort silently
                 self.notify_unassign()

--- a/linter.py
+++ b/linter.py
@@ -49,7 +49,10 @@ except NameError:
 class Mypy(PythonLinter):
     """Provides an interface to mypy."""
 
-    regex = r'^(\w:)?[^:]+:(?P<line>\d+):((?P<col>\d+):)?\s*(?P<error_type>[^:]+):\s*(?P<message>.+)'
+    regex = (
+        r'^(?P<filename>.+?):(?P<line>\d+):((?P<col>\d+):)?\s*'
+        r'(?P<error_type>[^:]+):\s*(?P<message>.+?)(\s\s\[(?P<code>.+)\])?$'
+    )
     line_col_base = (1, 1)
     tempfile_suffix = 'py'
     default_type = const.WARNING
@@ -63,6 +66,7 @@ class Mypy(PythonLinter):
         "--cache-dir:": "",
         # Allow users to disable this
         "--incremental": True,
+        "--show-error-codes": True,
         # Need this to silent lints for other files. Alternatively: 'skip'
         "--follow-imports:": "silent",
     }

--- a/linter.py
+++ b/linter.py
@@ -11,14 +11,26 @@
 
 """This module exports the Mypy plugin class."""
 
+import hashlib
 import logging
 import os
 import shutil
 import tempfile
+import time
 import getpass
 
 from SublimeLinter.lint import const
 from SublimeLinter.lint import PythonLinter
+from SublimeLinter.lint.linter import PermanentError
+
+
+MYPY = False
+if MYPY:
+    from typing import Dict, Protocol
+
+    class TemporaryDirectory(Protocol):
+        name = None  # type: str
+
 
 USER = getpass.getuser()
 TMPDIR_PREFIX = "SublimeLinter-contrib-mypy-%s" % USER
@@ -28,7 +40,10 @@ logger = logging.getLogger("SublimeLinter.plugin.mypy")
 # Mapping for our created temporary directories.
 # For smarter caching purposes,
 # we index different cache folders based on the working dir.
-tmpdirs = {}
+try:
+    tmpdirs
+except NameError:
+    tmpdirs = {}  # type: Dict[str, TemporaryDirectory]
 
 
 class Mypy(PythonLinter):
@@ -80,37 +95,87 @@ class Mypy(PythonLinter):
         # by not littering everything with `.mypy_cache` folders.
         if not self.settings.get('cache-dir'):
             cwd = self.get_working_dir()
-            if cwd in tmpdirs:
-                cache_dir = tmpdirs[cwd].name
+            if not cwd:  # abort silently
+                self.notify_unassign()
+                raise PermanentError()
+
+            if os.path.exists(os.path.join(cwd, '.mypy_cache')):
+                self.settings.set('cache-dir', False)  # do not set it as arg
             else:
-                tmp_dir = tempfile.TemporaryDirectory(prefix=TMPDIR_PREFIX)
-                tmpdirs[cwd] = tmp_dir
-                cache_dir = tmp_dir.name
-                logger.info("Created temporary cache dir at: %s", cache_dir)
-            cmd[1:1] = ["--cache-dir", cache_dir]
+                # Add a temporary cache dir to the command if none was specified.
+                # Helps keep the environment clean by not littering everything
+                # with `.mypy_cache` folders.
+                try:
+                    cache_dir = tmpdirs[cwd].name
+                except KeyError:
+                    tmpdirs[cwd] = tmp_dir = _get_tmpdir(cwd)
+                    cache_dir = tmp_dir.name
+
+                self.settings.set('cache-dir', cache_dir)
 
         return cmd
 
 
-def _cleanup_tmpdirs():
+class FakeTemporaryDirectory:
+    def __init__(self, name):
+        # type: (str) -> None
+        self.name = name
+
+
+def _get_tmpdir(folder):
+    # type: (str) -> TemporaryDirectory
+    folder_hash = hashlib.sha256(folder.encode('utf-8')).hexdigest()[:7]
+    tmpdir = tempfile.gettempdir()
+    for dirname in os.listdir(tmpdir):
+        if dirname.startswith(TMPDIR_PREFIX) and dirname.endswith(folder_hash):
+            path = os.path.join(tmpdir, dirname)
+            tmp_dir = FakeTemporaryDirectory(path)  # type: TemporaryDirectory
+            try:  # touch it so `_cleanup_tmpdirs` doesn't catch it
+                os.utime(path)
+            except OSError:
+                pass
+            logger.info("Reuse temporary cache dir at: %s", path)
+            return tmp_dir
+    else:
+        tmp_dir = tempfile.TemporaryDirectory(prefix=TMPDIR_PREFIX, suffix=folder_hash)
+        logger.info("Created temporary cache dir at: %s", tmp_dir.name)
+        return tmp_dir
+
+
+def _cleanup_tmpdirs(keep_recent=False):
+
     def _onerror(function, path, exc_info):
         logger.exception("Unable to delete '%s' while cleaning up temporary directory", path,
                          exc_info=exc_info)
+
     tmpdir = tempfile.gettempdir()
     for dirname in os.listdir(tmpdir):
         if dirname.startswith(TMPDIR_PREFIX):
-            shutil.rmtree(os.path.join(tmpdir, dirname), onerror=_onerror)
+            full_path = os.path.join(tmpdir, dirname)
+            if keep_recent:
+                try:
+                    atime = os.stat(full_path).st_atime
+                except OSError:
+                    pass
+                else:
+                    if (time.time() - atime) / 60 / 60 / 24 < 14:
+                        continue
+
+            shutil.rmtree(full_path, onerror=_onerror)
 
 
 def plugin_loaded():
     """Attempt to clean up temporary directories from previous runs."""
-    _cleanup_tmpdirs()
+    _cleanup_tmpdirs(keep_recent=True)
 
 
 def plugin_unloaded():
-    """Clear references to TemporaryDirectory instances.
+    try:
+        from package_control import events
 
-    They should then be removed automatically.
-    """
-    # (Actually, do we even need to do this?)
-    tmpdirs.clear()
+        if events.remove('SublimeLinter-contrib-mypy'):
+            logger.info("Cleanup temporary directories.")
+            _cleanup_tmpdirs()
+
+    except ImportError:
+        pass

--- a/linter.py
+++ b/linter.py
@@ -61,12 +61,10 @@ class Mypy(PythonLinter):
     defaults = {
         'selector': "source.python",
         # Will default to tempfile.TemporaryDirectory if empty.
-        "--cache-dir:": "",
-        # Allow users to disable this
-        "--incremental": True,
+        "--cache-dir": "",
         "--show-error-codes": True,
         # Need this to silent lints for other files. Alternatively: 'skip'
-        "--follow-imports:": "silent",
+        "--follow-imports": "silent",
     }
 
     def cmd(self):
@@ -76,7 +74,6 @@ class Mypy(PythonLinter):
             '${args}',
             '--show-column-numbers',
             '--hide-error-context',
-            # '--incremental',
         ]
         if self.filename:
             cmd.extend([

--- a/linter.py
+++ b/linter.py
@@ -19,7 +19,6 @@ import tempfile
 import time
 import getpass
 
-from SublimeLinter.lint import const
 from SublimeLinter.lint import PythonLinter
 from SublimeLinter.lint.linter import PermanentError
 
@@ -55,7 +54,6 @@ class Mypy(PythonLinter):
     )
     line_col_base = (1, 1)
     tempfile_suffix = 'py'
-    default_type = const.WARNING
 
     # Pretty much all interesting options don't expect a value,
     # so you'll have to specify those in "args" anyway.

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,0 +1,10 @@
+[mypy]
+check_untyped_defs = True
+warn_redundant_casts = True
+warn_unused_ignores = True
+mypy_path =
+  ../
+sqlite_cache = True
+
+[mypy-package_control]
+ignore_missing_imports = True


### PR DESCRIPTION
I noticed I actually run a different version of this plugin since a long time now.  Sorry, this is a rather unfocused PR. 

Improvements/changes:

- If there is a `.mypy_cache` folder in the project just use (respect) that.

- Do not check a falsy value for `cache-dir`. Leave the automatic default to `''`, but if the user sets explicitly `False`, respect that.  (Typical in the mypy.ini we can say where the cache is located, so it is good to somehow disable the automatic behavior.)

- If there is no working dir (t.i. no open folder for that window typically) do not lint at all. (This fixes an edge case really, when `working_dir` is `None` we don't have a stable key for `tmpdirs` and hence the chance that unrelated stranded files share the same cache folder.)

- Do not clean *all* cache folder on reload which is triggered on startup, and for example when SublimeLinter hot reloads. The caches are very expensive to compute, and so we try to keep them if possible (if the cache is used within the last 14 days). (That's a tricky first commit here, and I hope I didn't messed it up while squashing and preparing this PR.)

- Capture the error-`code` and `filename`. `code` is supported via mypy's `show-error-codes` flag (maybe roughly a year old), `filename` is supported by SublimeLinter core also since a year or so. (That also means users can actually *follow* imports now. SublimeLinter accepts errors from multiple files in one go.)

- Allow only one mypy process per cache (basically per project or working dir). This is a bug fix; SublimeLinter actually tries to run mypy on multiple files in the background, but mypy does not lock the caches. It is strictly forbidden to run mypy on the same folder concurrently, so we ensure that with a lock. (This is cheaply implemented but just enough since we're not "highly" concurrent here in this context, usually these processes would just overlap a bit.)

