### PR TITLE
Small iteration on the plugin

### DIFF
--- a/linter.py
+++ b/linter.py
@@ -53,7 +53,7 @@ class Mypy(PythonLinter):
 
     regex = (
         r'^(?P<filename>.+?):(?P<line>\d+):((?P<col>\d+):)?\s*'
-        r'(?P<error_type>[^:]+):\s*(?P<message>.+?)(\s\s\[(?P<code>.+)\])?$'
+        r'(?P<error_type>[^:]+):\s(?P<message>.+?)(\s\s\[(?P<code>.+)\])?$'
     )
     line_col_base = (1, 1)
     tempfile_suffix = 'py'

--- a/linter.py
+++ b/linter.py
@@ -77,6 +77,7 @@ class Mypy(PythonLinter):
             '${args}',
             '--show-column-numbers',
             '--hide-error-context',
+            '--no-error-summary',
         ]
         if self.filename:
             cmd.extend([


### PR DESCRIPTION
1. Do not eat whitespace from the message 

mypy might add leading whitespace to messages, it's like a form of
indentation, to help with readability.  Keep these!

2. Tell mypy to omit the summary output as we don't parse it anyway

3. Combine errors with their notes by merging their messages

4. Throw away `"x" defined here` note which is not helpful here

E.g. (*after*):

![image](https://user-images.githubusercontent.com/8558/187312402-1853737e-c0ef-402e-a6a0-298881984fd6.png)

You see some indentation in the long message (1).  And the long message is actually one error with some notes integrated (3)

(before)

![image](https://user-images.githubusercontent.com/8558/187312568-8af01bea-aa1f-42ed-b7f5-f64aaabd075b.png)

Also the first error "bark" defined here has been removed. (4)