### PR TITLE
Adopt for newer mypy options

### DIFF
--- a/linter.py
+++ b/linter.py
@@ -75,6 +75,7 @@ class Mypy(PythonLinter):
         cmd = [
             'mypy',
             '${args}',
+            '--no-pretty',
             '--show-column-numbers',
             '--hide-error-context',
             '--no-error-summary',

--- a/linter.py
+++ b/linter.py
@@ -21,8 +21,7 @@ import time
 import threading
 import getpass
 
-from SublimeLinter.lint import LintMatch, PythonLinter
-from SublimeLinter.lint.linter import PermanentError
+from SublimeLinter.lint import LintMatch, PermanentError, PythonLinter
 
 
 MYPY = False

--- a/tests/test_regex.py
+++ b/tests/test_regex.py
@@ -41,6 +41,22 @@ class TestRegex(unittest.TestCase):
                 'col': None,
                 'message': '"dict" is not subscriptable, use "typing.Dict" instead'})
 
+        self.assertMatch(
+            'codespell_lib\\tests\\test_basic.py:518:5:518:13: error: Module has no attribute "mkfifo"  [attr-defined]', {
+                'line': 517,
+                'col': 4,
+                'end_line': 517,
+                'end_col': 12,
+            })
+
+        self.assertMatch(
+            'codespell_lib\\tests\\test_basic.py:-1:-1:-1:-1: error: Module has no attribute "mkfifo"  [attr-defined]', {
+                'line': 0,
+                'col': None,
+                'end_line': None,
+                'end_col': None,
+            })
+
     def test_tmp_files_that_have_no_file_extension(self):
         self.assertMatch(
             '/tmp/yoeai32h2:6:1: error: Cannot find module named \'PackageName.lib\'', {


### PR DESCRIPTION
- mypy has a `--pretty` flag for a prettier outpur but we need to turn this off as it confuses our regex.  (A user can have this set for example in their `pyproject.toml`.)
- mypy has recently learned to show error ranges.  Support this new format, but we can't turn it on right now for everyone as it is just in the latest release.  (The format is `filename:line:col:en_line:end_col: `.) The PR says mypy will report `-1` for unknown values and we watch out for these although I could not find a case when mypy actually did report such a `-1`.  (I actually found a case where it just omitted the numbers 🙄.)
 